### PR TITLE
Add stack operation for tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ failing
   takeExampleFail : Tensor [10, 2] Double
   takeExampleFail = takeTensor [10, 2] t0
 
+||| Stacking tensors introduces a new leading axis
+stackExample : Tensor [2, 3, 4] Double
+stackExample = stack [t0, t0]
+
 
 ----------------------------------------
 -- Generalised tensor examples

--- a/examples/BasicExamples.idr
+++ b/examples/BasicExamples.idr
@@ -76,6 +76,10 @@ failing
   takeExampleFail : Tensor [10, 2] Double
   takeExampleFail = takeTensor [10, 2] t0
 
+||| Stacking tensors introduces a new leading axis
+stackExample : Tensor [2, 3, 4] Double
+stackExample = stack [t0, t0]
+
 
 ----------------------------------------
 -- Generalised tensor examples

--- a/src/Data/Tensor/Tensor.idr
+++ b/src/Data/Tensor/Tensor.idr
@@ -878,8 +878,19 @@ namespace SliceTensor
     Tensor shape a ->
     Tensor (sliceToShape slice) a
   takeTensor [] (ToCubicalTensor (TZ val)) = ToCubicalTensor (TZ val)
-  takeTensor (s :: ss) (ToCubicalTensor (TS xs)) = ToCubicalTensor $ TS $ 
+  takeTensor (s :: ss) (ToCubicalTensor (TS xs)) = ToCubicalTensor $ TS $
     (\t => FromCubicalTensor ((takeTensor ss) (ToCubicalTensor t))) <$> takeFinVect' s xs
+
+namespace StackTensor
+  ||| Stack a vector of tensors along a new leading axis
+  public export
+  stackA : {shape : List ContA} -> Vect n (TensorA shape a) -> TensorA (Vect n :: shape) a
+  stackA ts = TS (fromVect ts)
+
+  ||| Stack a vector of cubical tensors along a new leading axis
+  public export
+  stack : {shape : List Nat} -> Vect n (Tensor shape a) -> Tensor (n :: shape) a
+  stack ts = ToCubicalTensor $ stackA (FromCubicalTensor <$> ts)
 
   -- namespace FullSlicing
   --   -- Supporting optional exclusion of an axis in slicing


### PR DESCRIPTION
## Summary
- implement `stack` and `stackA` for combining tensors along a new leading axis
- add examples demonstrating tensor stacking
- document new stacking feature in README

## Testing
- `pack build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09d0a9430832f8749fce007625342